### PR TITLE
Change diskSpace to be UInt16

### DIFF
--- a/CollabVm.capnp
+++ b/CollabVm.capnp
@@ -14,7 +14,7 @@ struct CollabVmServerMessage {
     uploads @5 :Bool;
     input @6 :Bool;
     ram @7 :UInt8;
-    diskSpace @8 :UInt8;
+    diskSpace @8 :UInt16;
     safeForWork @9 :Bool;
     viewerCount @10 :UInt16;
   }


### PR DESCRIPTION
Currently, disk spaces cannot be set to >255 GB due to diskDpsace being UInt8. Since some VMs may have more than 255 GB of disk space (or other scenarios like more than 255 MB of disk space) its better for it to be a UInt16 instead.